### PR TITLE
Updated Vault to support disabling client cert requests

### DIFF
--- a/libraries/vault_config.rb
+++ b/libraries/vault_config.rb
@@ -43,6 +43,7 @@ module VaultCookbook
       attribute(:tls_cipher_suites, kind_of: String)
       attribute(:tls_prefer_server_cipher_suites, kind_of: String)
       attribute(:tls_require_and_verify_client_cert, kind_of: String)
+      attribute(:tls_disable_client_certs, kind_of: String)
       attribute(:tls_client_ca_file, kind_of: String)
       # Global options
       attribute(:cluster_name, kind_of: String)
@@ -82,7 +83,7 @@ module VaultCookbook
         end
         # listener
         listener_keeps = %i(address cluster_address proxy_protocol_behavior proxy_protocol_authorized_addrs)
-        tls_params = %i(tls_cert_file tls_key_file tls_min_version tls_cipher_suites tls_prefer_server_cipher_suites tls_require_and_verify_client_cert tls_client_ca_file)
+        tls_params = %i(tls_cert_file tls_key_file tls_min_version tls_cipher_suites tls_prefer_server_cipher_suites tls_require_and_verify_client_cert tls_client_ca_file tls_disable_client_certs)
         listener_keeps += tls_params if tls?
         listener_options = to_hash.keep_if do |k, _|
           listener_keeps.include?(k.to_sym)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Application cookbook for installing and configuring Vault.'
 long_description 'Application cookbook for installing and configuring Vault.'
 issues_url 'https://github.com/johnbellone/vault-cookbook/issues'
 source_url 'https://github.com/johnbellone/vault-cookbook/'
-version '1002.5.0'
+version '1002.6.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.4'


### PR DESCRIPTION
Enabled setting `tls_disable_client_certs` option to disable forcing requests for TLS auth.  This is needed to allow the Vault 0.10.X UI to work.