### PR TITLE
remove golang version constraint

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ supports 'windows'
 supports 'freebsd'
 
 depends 'build-essential'
-depends 'golang', '~> 1.7'
+depends 'golang', '>= 0.0.0'
 depends 'poise', '~> 2.6'
 depends 'poise-service', '~> 1.1'
 depends 'rubyzip', '~> 1.0'


### PR DESCRIPTION
Remove the golang cookbook version constraint, as this breaks the contraints while building lockfiles.

Flow: No version constraint in cookbook, but the policyfile will define the version pinning.
Tests: Success