### PR TITLE
Enable enterprise Vault upgrades

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,27 @@ suites:
       <<: *default-provisioner
       attributes:
         hashicorp-vault:
-          version: 1.8.4
           config:
             unauthenticated_metrics_access: true
+  - name: test_license
+    provisioner:
+      <<: *default-provisioner
+      attributes:
+        hashicorp-vault:
+          license_content: <%= ENV['VAULT_LICENSE'] %>
+  - name: test_license_external_ent
+    provisioner:
+      <<: *default-provisioner
+      attributes:
+        hashicorp-vault:
+          enterprise: true
+          license_content: <%= ENV['VAULT_LICENSE'] %>
+  - name: test_license_internal_ent
+    provisioner:
+      <<: *default-provisioner
+      attributes:
+        hashicorp-vault:
+          archive_url_root: "cdn.aws.robloxlabs.com"
+          enterprise: true
+          use_internal_repos: true
+          license_content: <%= ENV['VAULT_LICENSE'] %>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,13 +12,15 @@ default['hashicorp-vault']['service_name'] = 'vault'
 default['hashicorp-vault']['service_user'] = 'vault'
 default['hashicorp-vault']['service_group'] = 'vault'
 
-default['hashicorp-vault']['version'] = '1.6.1'
+default['hashicorp-vault']['version'] = '1.8.5'
 
 default['hashicorp-vault']['archive_url_root'] = 'releases.hashicorp.com'
 
 default['hashicorp-vault']['enterprise'] = false
+default['hashicorp-vault']['use_internal_repos'] = false
 
 default['hashicorp-vault']['config']['path'] = '/etc/vault/vault.json'
+default['hashicorp-vault']['config']['license_path'] = '/etc/vault/vault_license.hclic'
 default['hashicorp-vault']['config']['address'] = '127.0.0.1:8200'
 default['hashicorp-vault']['config']['log_level'] = 'info'
 default['hashicorp-vault']['config']['tls_cert_file'] = '/etc/vault/ssl/certs/vault.crt'

--- a/libraries/vault_installation.rb
+++ b/libraries/vault_installation.rb
@@ -37,6 +37,11 @@ module VaultCookbook
       # @return [boolean]
       attribute(:enterprise, equal_to: [true, false])
 
+      # @!attribute use_internal_repos
+      # Install using internal repos or not
+      # @return [boolean]
+      attribute(:use_internal_repos, equal_to: [true, false])
+
       def vault_program
         @program ||= provider_for_action(:vault_program).vault_program
       end

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,4 +1,4 @@
-describe file('/opt/vault/1.6.1/vault') do
+describe file('/opt/vault/1.8.5/vault') do
   it { should be_file }
   it { should be_executable }
 end

--- a/test/integration/test_license/inspec/default_spec.rb
+++ b/test/integration/test_license/inspec/default_spec.rb
@@ -17,7 +17,14 @@ describe file('/etc/vault/vault.json') do
   it { should be_owned_by 'vault' }
   it { should be_grouped_into 'vault' }
   its('content') { should match /.*log_level.*/ }
-  its('content') { should match /.*unauthenticated_metrics_access": true.*/}
+  its('content') { should match /.*license_path.*/}
+end
+
+describe file('/etc/vault/vault_license.hclic') do
+  it {should exist}
+  it {should be_file}
+  it { should be_owned_by 'vault' }
+  it { should be_grouped_into 'vault' }
 end
 
 describe service('vault') do

--- a/test/integration/test_license_external_ent/inspec/default_spec.rb
+++ b/test/integration/test_license_external_ent/inspec/default_spec.rb
@@ -17,7 +17,14 @@ describe file('/etc/vault/vault.json') do
   it { should be_owned_by 'vault' }
   it { should be_grouped_into 'vault' }
   its('content') { should match /.*log_level.*/ }
-  its('content') { should match /.*unauthenticated_metrics_access": true.*/}
+  its('content') { should match /.*license_path.*/}
+end
+
+describe file('/etc/vault/vault_license.hclic') do
+  it {should exist}
+  it {should be_file}
+  it { should be_owned_by 'vault' }
+  it { should be_grouped_into 'vault' }
 end
 
 describe service('vault') do

--- a/test/integration/test_license_internal_ent/inspec/default_spec.rb
+++ b/test/integration/test_license_internal_ent/inspec/default_spec.rb
@@ -17,7 +17,14 @@ describe file('/etc/vault/vault.json') do
   it { should be_owned_by 'vault' }
   it { should be_grouped_into 'vault' }
   its('content') { should match /.*log_level.*/ }
-  its('content') { should match /.*unauthenticated_metrics_access": true.*/}
+  its('content') { should match /.*license_path.*/}
+end
+
+describe file('/etc/vault/vault_license.hclic') do
+  it {should exist}
+  it {should be_file}
+  it { should be_owned_by 'vault' }
+  it { should be_grouped_into 'vault' }
 end
 
 describe service('vault') do


### PR DESCRIPTION
- Adds a new variable `use_internal_repos`
  - Allows a user to be explicit about where the repos are, and pull vault binaries from Hashicorp's website.
  - Default is to use hashicorp repos. This maintains old behavior.
- Fixes enterprise license file configuration
  - A bug where the path was defined without license_content would fail.
- Changes default installed version to 1.8.5 from 1.6.1
- Add new tests for license file functionality and external binaries.