### PR TITLE
ICO-4170: Use Ctime instead of birthtime

### DIFF
--- a/libraries/vault_service.rb
+++ b/libraries/vault_service.rb
@@ -90,7 +90,7 @@ module VaultCookbook
             # if /var/log/vault exists and is not a link, move to /var/log/vault.[created_at timestamp]
             path = '/var/log/vault'
             if ::File.directory?(path) && !::File.symlink?(path)
-              created_at = ::File.birthtime(path).strftime('%Y%m%d%H%M%S')
+              created_at = ::File.ctime(path).strftime('%Y%m%d%H%M%S')
               new_path = "#{path}.#{created_at}"
               ::FileUtils.mv(path, new_path)
             end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Application cookbook for installing and configuring Vault.'
 long_description 'Application cookbook for installing and configuring Vault.'
 issues_url 'https://github.com/johnbellone/vault-cookbook/issues'
 source_url 'https://github.com/johnbellone/vault-cookbook/'
-version '1002.7.10'
+version '1002.7.11'
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.4'


### PR DESCRIPTION
We are hitting chef errors when using `::File.birthtime(path)`, change to use ctime, we have verified ctime works via `chef-shell -z`