### PR TITLE
Update tests and minor version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Application cookbook for installing and configuring Vault.'
 long_description 'Application cookbook for installing and configuring Vault.'
 issues_url 'https://github.com/johnbellone/vault-cookbook/issues'
 source_url 'https://github.com/johnbellone/vault-cookbook/'
-version '1002.7.14'
+version '1002.8.1'
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.4'

--- a/test/fixtures/policies/default.lock.json
+++ b/test/fixtures/policies/default.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "59638ac2d01c191df467c767cbf6c12e168b209a47f4bc6677a62c73587a3a81",
+  "revision_id": "cf88d87c2e217b43768c138a26d14d6f6aa42c90d5f9ef327d76b2da484ab99e",
   "name": "default",
   "run_list": [
     "recipe[hashicorp-vault::default]"
@@ -43,14 +43,14 @@
     },
     "hashicorp-vault": {
       "version": "1002.7.14",
-      "identifier": "f587e66bf37fb7bcc5f5c0e40691b6c9c5e749d6",
-      "dotted_decimal_identifier": "69110793017458615.53134954915432081.200977724950998",
+      "identifier": "43b55d582607b499299d4ab83675d312ac31bea1",
+      "dotted_decimal_identifier": "19058235955087284.43111426976921205.232077151813281",
       "source": "../../..",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "3443293dd9c1e9571e8b49f4ad2d33db00a58c46",
+        "revision": "8ad3efdd3d6ac6282438455d6d962763419f0368",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -5,6 +5,8 @@ end
 
 describe file('/var/log/vault') do
   it { should be_directory }
+  it { should be_owned_by 'vault' }
+  it { should be_grouped_into 'vault' }
 end
 
 describe group('vault') do


### PR DESCRIPTION
A prior change is sufficiently breaking to our conventional use of this cookbook that I find it warranted to update the minor version rather than the patch version at this point.

Also, update tests to check ownership of /var/log/vault as well because why not.